### PR TITLE
Add quick and dirty way of specifying mode

### DIFF
--- a/lib/docsplit/text_extractor.rb
+++ b/lib/docsplit/text_extractor.rb
@@ -67,8 +67,10 @@ module Docsplit
           escaped_tiff = ESCAPE[tiff]
           file = "#{base_path}_#{page}"
           run "MAGICK_TMPDIR=#{tempdir} OMP_NUM_THREADS=2 gm convert -despeckle +adjoin #{MEMORY_ARGS} #{OCR_FLAGS} #{escaped_pdf}[#{page - 1}] #{escaped_tiff} 2>&1"
-          run "tesseract #{escaped_tiff} #{ESCAPE[file]} -l #{@language} #{@tesseract_options} #{@tesseract_config} 2>&1"
-          clean_text(file + '.txt') if @clean_ocr
+          run "tesseract #{escaped_tiff} #{ESCAPE[file]} -l #{@language} #{@tesseract_options} #{@tesseract_config} #{@tesseract_mode} 2>&1"
+          if ["", "text"].include(@tesseract_mode)
+            clean_text(file + '.txt') if @clean_ocr
+          end
           FileUtils.remove_entry_secure tiff
         end
       else
@@ -76,8 +78,10 @@ module Docsplit
         escaped_tiff = ESCAPE[tiff]
         run "MAGICK_TMPDIR=#{tempdir} OMP_NUM_THREADS=2 gm convert -despeckle #{MEMORY_ARGS} #{OCR_FLAGS} #{escaped_pdf} #{escaped_tiff} 2>&1"
         #if the user says don't do orientation detection or the plugin is not installed, set psm to 0
-        run "tesseract #{escaped_tiff} #{base_path} -l #{@language} #{@tesseract_options} #{@tesseract_config} 2>&1"
-        clean_text(base_path + '.txt') if @clean_ocr
+        run "tesseract #{escaped_tiff} #{base_path} -l #{@language} #{@tesseract_options} #{@tesseract_config} #{@tesseract_mode} 2>&1"
+        if ["", "text"].include(@tesseract_mode)
+          clean_text(base_path + '.txt') if @clean_ocr
+        end
       end
     ensure
       FileUtils.remove_entry_secure tempdir if File.exists?(tempdir)
@@ -138,6 +142,7 @@ module Docsplit
       @keep_layout        = options.fetch(:layout, false)
       @tesseract_options  = options[:tesseract_options] || ""
       @tesseract_config   = options[:tesseract_config] || ""
+      @tesseract_mode     = options[:tesseract_mode] || ""
     end
 
   end


### PR DESCRIPTION
This allows for specifying other output modes (such as `hocr`) to the tesseract options.